### PR TITLE
Moved Streamlit Header Down

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "[python]": {
+    "editor.defaultFormatter": "ms-python.autopep8"
+  },
+  "python.formatting.provider": "none"
+}

--- a/guide_sidebar.py
+++ b/guide_sidebar.py
@@ -1,0 +1,7 @@
+import time
+import streamlit as st
+
+with st.sidebar:
+    st.header("Sidebar Content")
+
+st.title("Main Content")

--- a/guide_sidebar.py
+++ b/guide_sidebar.py
@@ -1,7 +1,30 @@
-import time
 import streamlit as st
 
-with st.sidebar:
-    st.header("Sidebar Content")
+# Initialize a session state variable that tracks the sidebar state (either 'expanded' or 'collapsed').
+if 'sidebar_state' not in st.session_state:
+    st.session_state.sidebar_state = 'expanded'
 
-st.title("Main Content")
+# Streamlit set_page_config method has a 'initial_sidebar_state' argument that controls sidebar state.
+st.set_page_config(initial_sidebar_state=st.session_state.sidebar_state)
+
+m = st.markdown("""
+<style>
+div.stButton > button:first-child {
+    color: black;
+    border-radius: 50%;
+    
+}
+</style>""", unsafe_allow_html=True)
+
+# Show title and description of the app.
+st.title('Example: Controlling sidebar programmatically')
+st.sidebar.markdown(
+    'This is an example Streamlit app to show how to expand and collapse the sidebar programmatically.')
+
+button = st.button('Open &#xa; Guide')
+
+# Toggle sidebar state between 'expanded' and 'collapsed'.
+if button:
+    st.session_state.sidebar_state = 'collapsed' if st.session_state.sidebar_state == 'expanded' else 'expanded'
+    # Force an app rerun after switching the sidebar state.
+    st.experimental_rerun()

--- a/guide_sidebar.py
+++ b/guide_sidebar.py
@@ -1,0 +1,29 @@
+import streamlit as st
+
+# Initialize a session state variable that tracks the sidebar state (either 'expanded' or 'collapsed').
+if 'sidebar_state' not in st.session_state:
+    st.session_state.sidebar_state = 'expanded'
+
+# Streamlit set_page_config method has a 'initial_sidebar_state' argument that controls sidebar state.
+st.set_page_config(initial_sidebar_state=st.session_state.sidebar_state, layout= 'wide')
+
+m = st.markdown("""
+<style>
+div.stButton > button:first-child {
+    color: black;
+    border-radius: 50%; 
+}
+</style>""", unsafe_allow_html=True)
+
+# Show title and description of the app.
+st.title('Example: Controlling sidebar programmatically')
+st.sidebar.markdown(
+    'This is an example Streamlit app to show how to expand and collapse the sidebar programmatically.')
+
+button = st.button('Hello World')
+
+# Toggle sidebar state between 'expanded' and 'collapsed'.
+if button:
+    st.session_state.sidebar_state = 'collapsed' if st.session_state.sidebar_state == 'expanded' else 'expanded'
+    # Force an app rerun after switching the sidebar state.
+    st.experimental_rerun()

--- a/header.py
+++ b/header.py
@@ -1,0 +1,14 @@
+import streamlit as st
+import folium
+import pandas as pd
+import numpy as np
+import streamlit as st
+from streamlit_folium import folium_static
+
+with open("C:\\Users\\yummy\\OneDrive\\Documents\\h4i\\EDGI_Website\\style.css") as f:
+    st.markdown(
+        f"""<style>{f.read()}</style> <body>
+
+</body>""",
+        unsafe_allow_html=True,
+    )

--- a/revised_guide_sidebar.py
+++ b/revised_guide_sidebar.py
@@ -1,0 +1,172 @@
+import streamlit as st
+import folium
+import pandas as pd
+import streamlit as st
+from streamlit_folium import folium_static
+
+# Initialize a session state variable that tracks the sidebar state (either 'expanded' or 'collapsed').
+if 'sidebar_state' not in st.session_state:
+    st.session_state.sidebar_state = 'expanded'
+
+# Streamlit set_page_config method has a 'initial_sidebar_state' argument that controls sidebar state.
+st.set_page_config(initial_sidebar_state=st.session_state.sidebar_state, layout= 'wide')
+
+# map
+#TODO: do the style for map 
+# Create a Folium map
+map = folium.Map()
+
+# Define the HTML template with CSS to make the map full-screen
+map_html = """
+<style>
+iframe {
+    width: 100%;
+    min-height: 400px;
+    height: 100%;
+}
+</style>
+"""
+
+# Display the HTML template with the CSS to make the map full-screen using st.markdown
+st.markdown(map_html, unsafe_allow_html=True)
+
+# Display the map using st_folium
+st_data = folium_static(map)
+
+#TODO: make the style for the button
+# this is for the button
+if 'button' not in st.session_state:
+    st.session_state.button = False
+
+# Helper function to open/close the sidebar when the user presses the button
+def click_button():
+    st.session_state.button = not st.session_state.button
+
+# The button itself
+st.button('Open Guide', on_click=click_button)
+
+# TODO: need to add circles that can take on numbers
+
+def violations(per_fac, per_insp, per_enfo):
+  with st.container():
+    st.header("Violations per facility")
+  with st.container():
+    st.header("Violations per inspection")
+  with st.container():
+    st.header("Violations per enforcement")
+
+#TODO: get information for CAA, CWA, RCRA
+def gradingTab(bottom_info): 
+  st.header("") # creates a gap between
+  col1, col2 = st.columns(2)
+  with col1:
+    with st.container():
+      CAA, CWA, RCRA = st.tabs(["CAA", "CWA", "RCRA"])
+      with CAA: 
+        violations(17, 19,18) #test
+      with CWA:
+        violations(1, 2, 3) #test
+      with RCRA:
+        violations(7, 9,8) #test
+
+  with col2:
+    # Define the CSS style for the gray rectangle
+    gray_rectangle_style = """
+        background-color: #e6e6e6;
+        padding: 10px;
+        border-radius: 5px;
+        color: black;
+    """
+
+    # Define the HTML content as a string
+    html_content = f"""
+    <div style="{gray_rectangle_style}">
+        <subheader><b>Rationale for grading using these metrics:</b></subheader>
+        <ul>
+            <li>More <b>violations per active facility</b> are worse</li>
+            <li>More <b>inspections</b> mean more problems will be found, which is good. Dividing violations by inspections indicates the strength of the inspecting</li>
+            <li>More <b>enforcements</b> when violations are found disincentivizes violating. Dividing violations by enforcements indicates the willingness to call fouls</li>
+        </ul>
+    </div>
+    """
+
+    # Use st.markdown to render the HTML content
+    st.markdown(html_content, unsafe_allow_html=True)
+  
+  #bottom info
+  st.header("") # creates a gap
+  # Define a CSS style for the gray rectangle with curved edges
+  gray_rectangle_style = """
+    background-color: #e6e6e6;
+    padding: 10px;
+    border-radius: 5px;
+    color: black;
+  """
+
+  # Use st.markdown to display the gray rectangle with text
+  st.markdown(f'<div style="{gray_rectangle_style}">{bottom_info}</div>', unsafe_allow_html=True)
+
+# data visualization for the sidebar
+def fillSideBar(county=None, state=None, CAA_value = None, CWA_value = None, RCRA_value = None):
+  if st.session_state.button:
+    # User opens the sidebar
+    with st.sidebar:
+      if county is None or state is None:
+        st.header("How to use")
+
+        # Define your content as a string
+        content = """
+        Zoom in, search, or locate yourself and select a county or point to see county-specific data on violations, inspections, and enforcement actions under three laws:
+        - Clean Air Act (CAA)
+        - Clean Water Act (CWA)
+        - Resource Conservation and Recovery Act (RCRA)\n
+        You can also click on a state to view its counties, and click on a county to view the data.\n
+        Click on the circles within a county to zoom in and locate specific facilities. Hover over the facility’s circle to access its detailed ECHO report.
+        """
+
+        # Calculate the length of the content
+        content_length = len(content)
+
+        # Set the maximum width of the sidebar
+        max_sidebar_width = 500
+
+        # Calculate the sidebar width based on content length
+        sidebar_width = min(max_sidebar_width, content_length * 10)  # Adjust the multiplier as needed
+
+        # Set the width of the sidebar
+        st.markdown(f'<style>div.Widget.row-widget.stRadio > div {{ width: {sidebar_width}px !important; }}</style>', unsafe_allow_html=True)
+
+        # Display the content
+        st.markdown(content)
+      else:
+        st.header(county)
+        st.subheader(state)
+        st.header("")# Add an empty line to create space
+        #TODO: create a function that pulls data given the country and state
+        st.header("Operating Facilities")
+        st.text("CAA: " + str(CAA_value))
+        st.text("CWA: " + str(CWA_value))
+        st.text("RCRA: " + str(RCRA_value))
+        with st.container():
+          grading, highlight, compliance, non_compliance = st.tabs(["Grading", "Highlights", "District in Compliance", "Recent Non-Compliance"])
+
+          with grading:
+            #TODO: need a function here that grabs the information to be shown
+            gradingTab("test")
+
+          with highlight:
+            pass
+
+          with compliance:
+            pass
+
+          with non_compliance:
+            pass
+
+
+# Information that is shown when button is clicked
+if st.session_state.button:
+    # User opens the sidebar
+    with st.sidebar:
+      fillSideBar() #starter
+      #fillSideBar("hi","test", 72, 73,74)

--- a/revised_guide_sidebar.py
+++ b/revised_guide_sidebar.py
@@ -1,6 +1,7 @@
 import streamlit as st
 import folium
 import pandas as pd
+import numpy as np
 import streamlit as st
 from streamlit_folium import folium_static
 
@@ -17,6 +18,11 @@ map = folium.Map(location=[0.0, 0.0], zoom_start=2)
 # Define the HTML template with CSS to make the map full-screen
 map_html = """
 <style>
+body {
+    padding: 0;
+    margin: 0;
+    overflow: hidden;
+}
 iframe {
     width: 100%;
     min-height: 400px;
@@ -24,7 +30,6 @@ iframe {
 }
 </style>
 """
-# Display the HTML template with the CSS to make the map full-screen using st.markdown
 st.markdown(map_html, unsafe_allow_html=True)
 
 # Display the map using st_folium
@@ -57,15 +62,32 @@ div.stButton > button:first-child {
 </style>""", unsafe_allow_html=True)
 st.button('Open Guide', on_click=click_button,)
 
-# TODO: need to add circles that can take on number
+
+# Function to display words to the left and circles with text to the right
+def display_words_and_circles(word,number):
+  st.write(f'<div style="display: flex; align-items: center;">\
+    <div style="margin-right: 20px;"><h1>{word}</h1></div>\
+    <div style="\
+    width: 60px; \
+    height: 60px; \
+    background-color: #808080; \
+    border-radius: 50%; \
+    display: flex; \
+    align-items: center; \
+    justify-content: center; \
+    color: white; \
+    font-weight: bold; \
+    margin-left: auto; \
+    font-size: 20px;">{number}</div>\
+  </div>', unsafe_allow_html=True)
+
 def violations(per_fac, per_insp, per_enfo):
   with st.container():
-    st.header("Violations per facility")
+    display_words_and_circles("Violations per facility", per_fac)
   with st.container():
-    st.header("Violations per inspection")
+    display_words_and_circles("Violations per inspection", per_insp)
   with st.container():
-    st.header("Violations per enforcement")
-
+    display_words_and_circles("Violations per enforcement", per_enfo)
 
 def starter_top_info():
   st.title("How to use")
@@ -97,7 +119,7 @@ def starter_top_info():
 
 def gradingTabData():
   CAA, CWA, RCRA = st.tabs(["CAA", "CWA", "RCRA"])
-  with CAA: 
+  with CAA:
     violations(17, 19,18) #test
   with CWA:
     violations(1, 2, 3) #test
@@ -150,6 +172,51 @@ def highlightTabInfo():
     # Use st.markdown to render the HTML content
     st.markdown(html_content, unsafe_allow_html=True)
 
+def highlightTabData():
+  # Define the colors and words
+  colors = ["#8A6E95", "#89BAB9", "#E4AA7A"]
+  words = ["Bush", "Obama", "Trump"]
+
+  # Create a horizontal layout with colored boxes to the left of words
+  st.markdown(
+    """
+    <style>
+      .horizontal-layout {
+        display: inline-flex;  
+        align-items: center;
+      }
+      .color-box {
+        width: 24px;
+        height: 24px;
+        margin-right: 10px;
+      }
+    </style>
+    """,
+    unsafe_allow_html=True
+  )
+
+  for color, word in zip(colors, words):
+    st.markdown(
+      f'<div class="horizontal-layout">'
+      f'   <div class="color-box" style="background-color: {color};"></div>'
+      f'   {word}'
+      f'</div>',
+      unsafe_allow_html=True,
+  )
+  
+  st.markdown("<h2>Facility Inspections - CAA, CWA, RCRA</h2> <subtitle>Mostly complete data<subtitle>", unsafe_allow_html=True)
+  # this is a filler graph
+  chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
+  st.bar_chart(chart_data)
+  st.markdown("<h2>Facility Inspections - CAA, CWA, RCRA</h2> <subtitle>Potentially incomplete data<subtitle>", unsafe_allow_html=True)
+  # this is a filler graph
+  chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
+  st.bar_chart(chart_data)
+  st.markdown("<h2>Facility Inspections - CAA, CWA, RCRA</h2> <subtitle>Mostly incomplete data<subtitle>", unsafe_allow_html=True)
+  # this is a filler graph
+  chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
+  st.bar_chart(chart_data)
+
 def comparisonTabInfo():
   # Define the CSS style for the gray rectangle
     gray_rectangle_style = """
@@ -173,13 +240,59 @@ def comparisonTabInfo():
     # Use st.markdown to render the HTML content
     st.markdown(html_content, unsafe_allow_html=True)
 
-# Bottom part of the tabs 
+def comparisonTabData():
+  st.markdown("<h2 style='text-align: center'>Inspections per 1000 Facilities (2022)</h2>", unsafe_allow_html=True)
+  # this is where graph for CAA Violators
+  chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
+  st.bar_chart(chart_data)
+  st.markdown("<h2 style='text-align: center'>CWA Violators</h2>", unsafe_allow_html=True)
+  # this is where graph for CWA Violators
+  chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
+  st.bar_chart(chart_data)
+
+def non_complianceTabInfo():
+  # Define the CSS style for the gray rectangle
+    gray_rectangle_style = """
+        background-color: #e6e6e6;
+        padding: 10px;
+        border-radius: 5px;
+        color: black;
+    """
+
+    # Define the HTML content as a string
+    html_content = f"""
+    <div style="{gray_rectangle_style}">
+        <ul>
+            <li>Noncompliance is ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</li>
+            <li>These figures show the ten facilities in this state with the worst history of environmental compliance based on their number of noncompliant quarters in the past 3 years (not necessarily consecutive). Click on a facility name to view its ECHO report.</li>
+        </ul>
+    </div>
+    """
+
+    # Use st.markdown to render the HTML content
+    st.markdown(html_content, unsafe_allow_html=True)
+
+def non_complianceTabData(): 
+  st.markdown("<h2 style='text-align: center'>CAA Violators</h2>", unsafe_allow_html=True)
+  # this is where graph for CAA Violators
+  chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
+  st.bar_chart(chart_data)
+  st.markdown("<h2 style='text-align: center'>CWA Violators</h2>", unsafe_allow_html=True)
+  # this is where graph for CWA Violators
+  chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
+  st.bar_chart(chart_data)
+  st.markdown("<h2 style='text-align: center'>RCRA Violators</h>", unsafe_allow_html=True)
+  # this is where graph for RCRA Violators
+  chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
+  st.bar_chart(chart_data)
+   
+# Bottom info for the tabs 
 def bottom_info():
   st.header("") # creates a gap
 
   # Define a CSS style for the gray rectangle with curved edges
   gray_rectangle_style = """
-    background-color: #EFEFEF;
+    background-color: #e6e6e6;
     padding: 10px;
     border-radius: 5px;
     color: black;
@@ -205,9 +318,8 @@ def fillSideBar(county=None, state=None, CAA_value=0, CWA_value=0 , RCRA_value=0
         starter_top_info()
       else:
         st.title(county)
-        st.header(state)
-        st.header("")# Add an empty line to create space
-        #TODO: create a function that pulls data given the country and state
+        st.subheader(state)
+        st.header("") # Add an empty line to create space
         st.header("Operating Facilities")
         st.subheader("CAA: " + str(CAA_value))
         st.subheader("CWA: " + str(CWA_value))
@@ -215,30 +327,28 @@ def fillSideBar(county=None, state=None, CAA_value=0, CWA_value=0 , RCRA_value=0
         with st.container():
           grading, highlight, comparison, non_compliance = st.tabs(["Grading", "Highlights", "In Comparison", "Recent Non-Compliance"])
           with grading:
-            #TODO: need a function here that grabs the information to be shown & need the links 
             gradingTabData()
             bottom_info()
             gradingTabInfo()
 
           with highlight:
-            #TODO: make a highlightTabData() for the graphs
+            highlightTabData() 
             bottom_info()
             highlightTabInfo()
 
-          with comparison:
-            #TODO: make a comparisonTabData() for the graphs
+          with comparison: 
+            comparisonTabData()
             bottom_info()
             comparisonTabInfo()
-            
 
           with non_compliance:
-            #TODO: make a complianceTabData() for the graphs
+            non_complianceTabData()
             bottom_info()
-
+            non_complianceTabInfo()
 
 # Information that is shown when button is clicked
 if st.session_state.button:
     # User opens the sidebar
     with st.sidebar:
       #fillSideBar() #starter
-      fillSideBar("hi","test", 72, 73,74)
+      fillSideBar("Niagara County","New York", 72, 73,74)

--- a/revised_guide_sidebar.py
+++ b/revised_guide_sidebar.py
@@ -5,15 +5,16 @@ import numpy as np
 import streamlit as st
 from streamlit_folium import folium_static
 
+
 # Initialize a session state variable that tracks the sidebar state
 if 'sidebar_state' not in st.session_state:
     st.session_state.sidebar_state = 'expanded'
 
-# Streamlit set_page_config 
-st.set_page_config(layout= "wide")
+# Streamlit set_page_config
+st.set_page_config(layout="wide")
 
 # Create a Folium map that is zoomed-in a bit
-map = folium.Map(location=[0.0, 0.0], zoom_start=2)
+map = folium.Map(location=[0.0, 0.0], zoom_start=2, use_container_width=True)
 
 # Define the HTML template with CSS to make the map full-screen
 map_html = """
@@ -27,21 +28,27 @@ iframe {
     width: 100%;
     min-height: 400px;
     height: 600px;
+    border: none;
+    position: relative;
+    z-index: 1;
 }
 </style>
 """
 st.markdown(map_html, unsafe_allow_html=True)
 
 # Display the map using st_folium
-st_data = folium_static(map)
+folium_static(map)
 
 # this is for the button
 if 'button' not in st.session_state:
     st.session_state.button = False
 
 # Helper function to open/close the sidebar when the user presses the button
+
+
 def click_button():
     st.session_state.button = not st.session_state.button
+
 
 # The button itself styled
 m = st.markdown("""
@@ -58,14 +65,16 @@ div.stButton > button:first-child {
     border: 2px solid #3A7568;
     width: 70px;
     height: 70px; 
+    position: relative;
+    z-index: 2;
 }
 </style>""", unsafe_allow_html=True)
 st.button('Open Guide', on_click=click_button,)
 
 
 # Function to display words to the left and circles with text to the right
-def display_words_and_circles(word,number):
-  st.write(f'<div style="display: flex; align-items: center;">\
+def display_words_and_circles(word, number):
+    st.write(f'<div style="display: flex; align-items: center;">\
     <div style="margin-right: 20px;"><h1>{word}</h1></div>\
     <div style="\
     width: 60px; \
@@ -81,19 +90,21 @@ def display_words_and_circles(word,number):
     font-size: 20px;">{number}</div>\
   </div>', unsafe_allow_html=True)
 
+
 def violations(per_fac, per_insp, per_enfo):
-  with st.container():
-    display_words_and_circles("Violations per facility", per_fac)
-  with st.container():
-    display_words_and_circles("Violations per inspection", per_insp)
-  with st.container():
-    display_words_and_circles("Violations per enforcement", per_enfo)
+    with st.container():
+        display_words_and_circles("Violations per facility", per_fac)
+    with st.container():
+        display_words_and_circles("Violations per inspection", per_insp)
+    with st.container():
+        display_words_and_circles("Violations per enforcement", per_enfo)
+
 
 def starter_top_info():
-  st.title("How to use")
+    st.title("How to use")
 
-  # Define your content as a string
-  content = """
+    # Define your content as a string
+    content = """
   Zoom in or search to select a county to see county-specific data on violations, inspections, and enforcement actions by the EPA under the:
   - Clean Air Act (CAA)
   - Clean Water Act (CWA)
@@ -102,32 +113,36 @@ def starter_top_info():
   Click on the circles within a county to zoom in and locate specific facilities. Hover over the facility’s circle to access its detailed ECHO report.
   """
 
-  # Calculate the length of the content
-  content_length = len(content)
+    # Calculate the length of the content
+    content_length = len(content)
 
-  # Set the maximum width of the sidebar
-  max_sidebar_width = 500
+    # Set the maximum width of the sidebar
+    max_sidebar_width = 500
 
-  # Calculate the sidebar width based on content length
-  sidebar_width = min(max_sidebar_width, content_length * 10)  # Adjust the multiplier as needed
+    # Calculate the sidebar width based on content length
+    # Adjust the multiplier as needed
+    sidebar_width = min(max_sidebar_width, content_length * 10)
 
-  # Set the width of the sidebar
-  st.markdown(f'<style>div.Widget.row-widget.stRadio > div {{ width: {sidebar_width}px !important; }}</style>', unsafe_allow_html=True)
+    # Set the width of the sidebar
+    st.markdown(
+        f'<style>div.Widget.row-widget.stRadio > div {{ width: {sidebar_width}px !important; }}</style>', unsafe_allow_html=True)
 
-  # Display the content
-  st.markdown(content)
+    # Display the content
+    st.markdown(content)
+
 
 def gradingTabData():
-  CAA, CWA, RCRA = st.tabs(["CAA", "CWA", "RCRA"])
-  with CAA:
-    violations(17, 19,18) #test
-  with CWA:
-    violations(1, 2, 3) #test
-  with RCRA:
-    violations(7, 9,8) #test
+    CAA, CWA, RCRA = st.tabs(["CAA", "CWA", "RCRA"])
+    with CAA:
+        violations(17, 19, 18)  # test
+    with CWA:
+        violations(1, 2, 3)  # test
+    with RCRA:
+        violations(7, 9, 8)  # test
+
 
 def gradingTabInfo():
-  # Define the CSS style for the gray rectangle
+    # Define the CSS style for the gray rectangle
     gray_rectangle_style = """
         background-color: #e6e6e6;
         padding: 10px;
@@ -150,8 +165,9 @@ def gradingTabInfo():
     # Use st.markdown to render the HTML content
     st.markdown(html_content, unsafe_allow_html=True)
 
+
 def highlightTabInfo():
-  # Define the CSS style for the gray rectangle
+    # Define the CSS style for the gray rectangle
     gray_rectangle_style = """
         background-color: #e6e6e6;
         padding: 10px;
@@ -172,10 +188,11 @@ def highlightTabInfo():
     # Use st.markdown to render the HTML content
     st.markdown(html_content, unsafe_allow_html=True)
 
+
 def highlightTabData():
-  # Use st.markdown to render the HTML content
-  st.markdown(
-    """
+    # Use st.markdown to render the HTML content
+    st.markdown(
+        """
     <div style="display: flex; align-items: center;">
         <div>
             <h1 style="margin-right: 10px;">Key: President</h1>
@@ -190,26 +207,28 @@ def highlightTabData():
         </div>
     </div>
     """,
-    unsafe_allow_html=True
-)
+        unsafe_allow_html=True
+    )
 
+    st.markdown("<h2>Facility Inspections - CAA, CWA, RCRA</h2> <subtitle>Mostly complete data<subtitle>",
+                unsafe_allow_html=True)
+    # this is a filler graph
+    chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
+    st.bar_chart(chart_data)
+    st.markdown("<h2>Facility Inspections - CAA, CWA, RCRA</h2> <subtitle>Potentially incomplete data<subtitle>",
+                unsafe_allow_html=True)
+    # this is a filler graph
+    chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
+    st.bar_chart(chart_data)
+    st.markdown("<h2>Facility Inspections - CAA, CWA, RCRA</h2> <subtitle>Mostly incomplete data<subtitle>",
+                unsafe_allow_html=True)
+    # this is a filler graph
+    chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
+    st.bar_chart(chart_data)
 
-  
-  st.markdown("<h2>Facility Inspections - CAA, CWA, RCRA</h2> <subtitle>Mostly complete data<subtitle>", unsafe_allow_html=True)
-  # this is a filler graph
-  chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
-  st.bar_chart(chart_data)
-  st.markdown("<h2>Facility Inspections - CAA, CWA, RCRA</h2> <subtitle>Potentially incomplete data<subtitle>", unsafe_allow_html=True)
-  # this is a filler graph
-  chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
-  st.bar_chart(chart_data)
-  st.markdown("<h2>Facility Inspections - CAA, CWA, RCRA</h2> <subtitle>Mostly incomplete data<subtitle>", unsafe_allow_html=True)
-  # this is a filler graph
-  chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
-  st.bar_chart(chart_data)
 
 def comparisonTabInfo():
-  # Define the CSS style for the gray rectangle
+    # Define the CSS style for the gray rectangle
     gray_rectangle_style = """
         background-color: #e6e6e6;
         padding: 10px;
@@ -231,18 +250,22 @@ def comparisonTabInfo():
     # Use st.markdown to render the HTML content
     st.markdown(html_content, unsafe_allow_html=True)
 
+
 def comparisonTabData():
-  st.markdown("<h2 style='text-align: center'>Inspections per 1000 Facilities (2022)</h2>", unsafe_allow_html=True)
-  # this is where graph for CAA Violators
-  chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
-  st.bar_chart(chart_data)
-  st.markdown("<h2 style='text-align: center'>Violations per 1000 Facilities in 2022</h2>", unsafe_allow_html=True)
-  # this is where graph for CWA Violators
-  chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
-  st.bar_chart(chart_data)
+    st.markdown("<h2 style='text-align: center'>Inspections per 1000 Facilities (2022)</h2>",
+                unsafe_allow_html=True)
+    # this is where graph for CAA Violators
+    chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
+    st.bar_chart(chart_data)
+    st.markdown("<h2 style='text-align: center'>Violations per 1000 Facilities in 2022</h2>",
+                unsafe_allow_html=True)
+    # this is where graph for CWA Violators
+    chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
+    st.bar_chart(chart_data)
+
 
 def non_complianceTabInfo():
-  # Define the CSS style for the gray rectangle
+    # Define the CSS style for the gray rectangle
     gray_rectangle_style = """
         background-color: #e6e6e6;
         padding: 10px;
@@ -263,26 +286,32 @@ def non_complianceTabInfo():
     # Use st.markdown to render the HTML content
     st.markdown(html_content, unsafe_allow_html=True)
 
-def non_complianceTabData(): 
-  st.markdown("<h2 style='text-align: center'>CAA Violators</h2>", unsafe_allow_html=True)
-  # this is where graph for CAA Violators
-  chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
-  st.bar_chart(chart_data)
-  st.markdown("<h2 style='text-align: center'>CWA Violators</h2>", unsafe_allow_html=True)
-  # this is where graph for CWA Violators
-  chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
-  st.bar_chart(chart_data)
-  st.markdown("<h2 style='text-align: center'>RCRA Violators</h>", unsafe_allow_html=True)
-  # this is where graph for RCRA Violators
-  chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
-  st.bar_chart(chart_data)
-   
-# Bottom info for the tabs 
-def bottom_info():
-  st.header("") # creates a gap
 
-  # Define a CSS style for the gray rectangle with curved edges
-  gray_rectangle_style = """
+def non_complianceTabData():
+    st.markdown("<h2 style='text-align: center'>CAA Violators</h2>",
+                unsafe_allow_html=True)
+    # this is where graph for CAA Violators
+    chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
+    st.bar_chart(chart_data)
+    st.markdown("<h2 style='text-align: center'>CWA Violators</h2>",
+                unsafe_allow_html=True)
+    # this is where graph for CWA Violators
+    chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
+    st.bar_chart(chart_data)
+    st.markdown("<h2 style='text-align: center'>RCRA Violators</h>",
+                unsafe_allow_html=True)
+    # this is where graph for RCRA Violators
+    chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
+    st.bar_chart(chart_data)
+
+# Bottom info for the tabs
+
+
+def bottom_info():
+    st.header("")  # creates a gap
+
+    # Define a CSS style for the gray rectangle with curved edges
+    gray_rectangle_style = """
     background-color: #e6e6e6;
     padding: 10px;
     border-radius: 5px;
@@ -290,56 +319,61 @@ def bottom_info():
     font-size: 12px;
   """
 
-  # text for the bottom of the page
-  text = """The reliability of data in figures throughout this report is 
+    # text for the bottom of the page
+    text = """The reliability of data in figures throughout this report is 
   indicated by the figure subtitle and degree of transparency. See the Data 
   Limitations section to view the transparency-coding table. Access state and 
   congressional district data here."""
 
-  # Use st.markdown to display the gray rectangle with text
-  st.markdown(f'<div style="{gray_rectangle_style}">{text}</div>', unsafe_allow_html=True)
-  st.header("") # creates a gap
+    # Use st.markdown to display the gray rectangle with text
+    st.markdown(
+        f'<div style="{gray_rectangle_style}">{text}</div>', unsafe_allow_html=True)
+    st.header("")  # creates a gap
 
 # data visualization for the sidebar
-def fillSideBar(county=None, state=None, CAA_value=0, CWA_value=0 , RCRA_value=0):
-  if st.session_state.button:
-    # User opens the sidebar
-    with st.sidebar:
-      if county is None or state is None:
-        starter_top_info()
-      else:
-        st.title(county)
-        st.subheader(state)
-        st.header("") # Add an empty line to create space
-        st.header("Operating Facilities")
-        st.subheader("CAA: " + str(CAA_value))
-        st.subheader("CWA: " + str(CWA_value))
-        st.subheader("RCRA: " + str(RCRA_value))
-        with st.container():
-          grading, highlight, comparison, non_compliance = st.tabs(["Grading", "Highlights", "In Comparison", "Recent Non-Compliance"])
-          with grading:
-            gradingTabData()
-            bottom_info()
-            gradingTabInfo()
 
-          with highlight:
-            highlightTabData() 
-            bottom_info()
-            highlightTabInfo()
 
-          with comparison: 
-            comparisonTabData()
-            bottom_info()
-            comparisonTabInfo()
+def fillSideBar(county=None, state=None, CAA_value=0, CWA_value=0, RCRA_value=0):
+    if st.session_state.button:
+        # User opens the sidebar
+        with st.sidebar:
+            if county is None or state is None:
+                starter_top_info()
+            else:
+                st.title(county)
+                st.subheader(state)
+                st.header("")  # Add an empty line to create space
+                st.header("Operating Facilities")
+                st.subheader("CAA: " + str(CAA_value))
+                st.subheader("CWA: " + str(CWA_value))
+                st.subheader("RCRA: " + str(RCRA_value))
+                with st.container():
+                    grading, highlight, comparison, non_compliance = st.tabs(
+                        ["Grading", "Highlights", "In Comparison", "Recent Non-Compliance"])
+                    with grading:
+                        gradingTabData()
+                        bottom_info()
+                        gradingTabInfo()
 
-          with non_compliance:
-            non_complianceTabData()
-            bottom_info()
-            non_complianceTabInfo()
+                    with highlight:
+                        highlightTabData()
+                        bottom_info()
+                        highlightTabInfo()
+
+                    with comparison:
+                        comparisonTabData()
+                        bottom_info()
+                        comparisonTabInfo()
+
+                    with non_compliance:
+                        non_complianceTabData()
+                        bottom_info()
+                        non_complianceTabInfo()
+
 
 # Information that is shown when button is clicked
 if st.session_state.button:
     # User opens the sidebar
     with st.sidebar:
-      #fillSideBar() #starter
-      fillSideBar("Niagara County","New York", 72, 73,74)
+        # fillSideBar() #starter
+        fillSideBar("Niagara County", "New York", 72, 73, 74)

--- a/revised_guide_sidebar.py
+++ b/revised_guide_sidebar.py
@@ -173,36 +173,27 @@ def highlightTabInfo():
     st.markdown(html_content, unsafe_allow_html=True)
 
 def highlightTabData():
-  # Define the colors and words
-  colors = ["#8A6E95", "#89BAB9", "#E4AA7A"]
-  words = ["Bush", "Obama", "Trump"]
-
-  # Create a horizontal layout with colored boxes to the left of words
+  # Use st.markdown to render the HTML content
   st.markdown(
     """
-    <style>
-      .horizontal-layout {
-        display: inline-flex;  
-        align-items: center;
-      }
-      .color-box {
-        width: 24px;
-        height: 24px;
-        margin-right: 10px;
-      }
-    </style>
+    <div style="display: flex; align-items: center;">
+        <div>
+            <h1 style="margin-right: 10px;">Key: President</h1>
+        </div>
+        <div style="margin-left: auto; display: flex; align-items: center;">
+            <div style="background-color: #8A6E95; width: 20px; height: 20px; margin: 0;"></div>
+            <text style="margin: 5px; font-size: 20px;">Bush</text>
+            <div style="background-color: #89BAB9; width: 20px; height: 20px; margin: 0;"></div>
+            <text style="margin: 5px; font-size: 20px;">Obama</text>
+            <div style="background-color: #E4AA7A; width: 20px; height: 20px; margin: 0;"></div>
+            <text style="margin: 5px; font-size: 20px;">Trump</text>
+        </div>
+    </div>
     """,
     unsafe_allow_html=True
-  )
+)
 
-  for color, word in zip(colors, words):
-    st.markdown(
-      f'<div class="horizontal-layout">'
-      f'   <div class="color-box" style="background-color: {color};"></div>'
-      f'   {word}'
-      f'</div>',
-      unsafe_allow_html=True,
-  )
+
   
   st.markdown("<h2>Facility Inspections - CAA, CWA, RCRA</h2> <subtitle>Mostly complete data<subtitle>", unsafe_allow_html=True)
   # this is a filler graph
@@ -245,7 +236,7 @@ def comparisonTabData():
   # this is where graph for CAA Violators
   chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
   st.bar_chart(chart_data)
-  st.markdown("<h2 style='text-align: center'>CWA Violators</h2>", unsafe_allow_html=True)
+  st.markdown("<h2 style='text-align: center'>Violations per 1000 Facilities in 2022</h2>", unsafe_allow_html=True)
   # this is where graph for CWA Violators
   chart_data = pd.DataFrame(np.random.randn(20, 3), columns=["a", "b", "c"])
   st.bar_chart(chart_data)

--- a/revised_guide_sidebar.py
+++ b/revised_guide_sidebar.py
@@ -4,17 +4,15 @@ import pandas as pd
 import streamlit as st
 from streamlit_folium import folium_static
 
-# Initialize a session state variable that tracks the sidebar state (either 'expanded' or 'collapsed').
+# Initialize a session state variable that tracks the sidebar state
 if 'sidebar_state' not in st.session_state:
     st.session_state.sidebar_state = 'expanded'
 
-# Streamlit set_page_config method has a 'initial_sidebar_state' argument that controls sidebar state.
-st.set_page_config(initial_sidebar_state=st.session_state.sidebar_state, layout= 'wide')
+# Streamlit set_page_config 
+st.set_page_config(layout= "wide")
 
-# map
-#TODO: do the style for map 
-# Create a Folium map
-map = folium.Map()
+# Create a Folium map that is zoomed-in a bit
+map = folium.Map(location=[0.0, 0.0], zoom_start=2)
 
 # Define the HTML template with CSS to make the map full-screen
 map_html = """
@@ -22,18 +20,16 @@ map_html = """
 iframe {
     width: 100%;
     min-height: 400px;
-    height: 100%;
+    height: 600px;
 }
 </style>
 """
-
 # Display the HTML template with the CSS to make the map full-screen using st.markdown
 st.markdown(map_html, unsafe_allow_html=True)
 
 # Display the map using st_folium
 st_data = folium_static(map)
 
-#TODO: make the style for the button
 # this is for the button
 if 'button' not in st.session_state:
     st.session_state.button = False
@@ -42,11 +38,26 @@ if 'button' not in st.session_state:
 def click_button():
     st.session_state.button = not st.session_state.button
 
-# The button itself
-st.button('Open Guide', on_click=click_button)
+# The button itself styled
+m = st.markdown("""
+<style>
+div.stButton > button:first-child {
+    color: #3A7568;
+    border: #3A7568;
+    background: white;
+    border-radius: 50%; 
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    border: 2px solid #3A7568;
+    width: 70px;
+    height: 70px; 
+}
+</style>""", unsafe_allow_html=True)
+st.button('Open Guide', on_click=click_button,)
 
-# TODO: need to add circles that can take on numbers
-
+# TODO: need to add circles that can take on number
 def violations(per_fac, per_insp, per_enfo):
   with st.container():
     st.header("Violations per facility")
@@ -55,22 +66,46 @@ def violations(per_fac, per_insp, per_enfo):
   with st.container():
     st.header("Violations per enforcement")
 
-#TODO: get information for CAA, CWA, RCRA
-def gradingTab(bottom_info): 
-  st.header("") # creates a gap between
-  col1, col2 = st.columns(2)
-  with col1:
-    with st.container():
-      CAA, CWA, RCRA = st.tabs(["CAA", "CWA", "RCRA"])
-      with CAA: 
-        violations(17, 19,18) #test
-      with CWA:
-        violations(1, 2, 3) #test
-      with RCRA:
-        violations(7, 9,8) #test
 
-  with col2:
-    # Define the CSS style for the gray rectangle
+def starter_top_info():
+  st.title("How to use")
+
+  # Define your content as a string
+  content = """
+  Zoom in or search to select a county to see county-specific data on violations, inspections, and enforcement actions by the EPA under the:
+  - Clean Air Act (CAA)
+  - Clean Water Act (CWA)
+  - Resource Conservation and Recovery Act (RCRA)\n
+  You can also click on a state to view its counties, and click on a county to view the data.\n
+  Click on the circles within a county to zoom in and locate specific facilities. Hover over the facility’s circle to access its detailed ECHO report.
+  """
+
+  # Calculate the length of the content
+  content_length = len(content)
+
+  # Set the maximum width of the sidebar
+  max_sidebar_width = 500
+
+  # Calculate the sidebar width based on content length
+  sidebar_width = min(max_sidebar_width, content_length * 10)  # Adjust the multiplier as needed
+
+  # Set the width of the sidebar
+  st.markdown(f'<style>div.Widget.row-widget.stRadio > div {{ width: {sidebar_width}px !important; }}</style>', unsafe_allow_html=True)
+
+  # Display the content
+  st.markdown(content)
+
+def gradingTabData():
+  CAA, CWA, RCRA = st.tabs(["CAA", "CWA", "RCRA"])
+  with CAA: 
+    violations(17, 19,18) #test
+  with CWA:
+    violations(1, 2, 3) #test
+  with RCRA:
+    violations(7, 9,8) #test
+
+def gradingTabInfo():
+  # Define the CSS style for the gray rectangle
     gray_rectangle_style = """
         background-color: #e6e6e6;
         padding: 10px;
@@ -82,7 +117,7 @@ def gradingTab(bottom_info):
     html_content = f"""
     <div style="{gray_rectangle_style}">
         <subheader><b>Rationale for grading using these metrics:</b></subheader>
-        <ul>
+        <ul style: font-size: 12px>
             <li>More <b>violations per active facility</b> are worse</li>
             <li>More <b>inspections</b> mean more problems will be found, which is good. Dividing violations by inspections indicates the strength of the inspecting</li>
             <li>More <b>enforcements</b> when violations are found disincentivizes violating. Dividing violations by enforcements indicates the willingness to call fouls</li>
@@ -92,81 +127,118 @@ def gradingTab(bottom_info):
 
     # Use st.markdown to render the HTML content
     st.markdown(html_content, unsafe_allow_html=True)
-  
-  #bottom info
+
+def highlightTabInfo():
+  # Define the CSS style for the gray rectangle
+    gray_rectangle_style = """
+        background-color: #e6e6e6;
+        padding: 10px;
+        border-radius: 5px;
+        color: black;
+    """
+
+    # Define the HTML content as a string
+    html_content = f"""
+    <div style="{gray_rectangle_style}">
+        <ul>
+            <li> Comparing the first 3 years of the Obama administration to the first 3 years of the Trump administration, there has been a <b>2% decrease in inspections, 85% decrease in fines, and a 7% increase in enforcement actions.</b> </li>
+            <li> Under the Clean Water Act, the law whose regulation is best documented by available EPA data, <b> 759 facilities</b>, representing 44% of all regulated facilities in [county name], were in violation for at least 9 months of the last 3 years. </li>
+        </ul>
+    </div>
+    """
+
+    # Use st.markdown to render the HTML content
+    st.markdown(html_content, unsafe_allow_html=True)
+
+def comparisonTabInfo():
+  # Define the CSS style for the gray rectangle
+    gray_rectangle_style = """
+        background-color: #e6e6e6;
+        padding: 10px;
+        border-radius: 5px;
+        color: black;
+    """
+
+    # Define the HTML content as a string
+    html_content = f"""
+    <div style="{gray_rectangle_style}">
+        <ul>
+            <li>These two charts show how inspections and violations in this state compare to the national average per 1000 facilities in 2022</li>
+            <li>We use data from 2022 as it was the most recent full year and the ECHO database only reports currently active facilities</li>
+            <li>To enable comparison across locations with a differing number of active facilities, we standardize the comparison to a value per 1000 facilities, proportionally adjusting the data if there are more or less than 1000 facilities in a district or state</li>
+        </ul>
+    </div>
+    """
+
+    # Use st.markdown to render the HTML content
+    st.markdown(html_content, unsafe_allow_html=True)
+
+# Bottom part of the tabs 
+def bottom_info():
   st.header("") # creates a gap
+
   # Define a CSS style for the gray rectangle with curved edges
   gray_rectangle_style = """
-    background-color: #e6e6e6;
+    background-color: #EFEFEF;
     padding: 10px;
     border-radius: 5px;
     color: black;
+    font-size: 12px;
   """
 
+  # text for the bottom of the page
+  text = """The reliability of data in figures throughout this report is 
+  indicated by the figure subtitle and degree of transparency. See the Data 
+  Limitations section to view the transparency-coding table. Access state and 
+  congressional district data here."""
+
   # Use st.markdown to display the gray rectangle with text
-  st.markdown(f'<div style="{gray_rectangle_style}">{bottom_info}</div>', unsafe_allow_html=True)
+  st.markdown(f'<div style="{gray_rectangle_style}">{text}</div>', unsafe_allow_html=True)
+  st.header("") # creates a gap
 
 # data visualization for the sidebar
-def fillSideBar(county=None, state=None, CAA_value = None, CWA_value = None, RCRA_value = None):
+def fillSideBar(county=None, state=None, CAA_value=0, CWA_value=0 , RCRA_value=0):
   if st.session_state.button:
     # User opens the sidebar
     with st.sidebar:
       if county is None or state is None:
-        st.header("How to use")
-
-        # Define your content as a string
-        content = """
-        Zoom in, search, or locate yourself and select a county or point to see county-specific data on violations, inspections, and enforcement actions under three laws:
-        - Clean Air Act (CAA)
-        - Clean Water Act (CWA)
-        - Resource Conservation and Recovery Act (RCRA)\n
-        You can also click on a state to view its counties, and click on a county to view the data.\n
-        Click on the circles within a county to zoom in and locate specific facilities. Hover over the facility’s circle to access its detailed ECHO report.
-        """
-
-        # Calculate the length of the content
-        content_length = len(content)
-
-        # Set the maximum width of the sidebar
-        max_sidebar_width = 500
-
-        # Calculate the sidebar width based on content length
-        sidebar_width = min(max_sidebar_width, content_length * 10)  # Adjust the multiplier as needed
-
-        # Set the width of the sidebar
-        st.markdown(f'<style>div.Widget.row-widget.stRadio > div {{ width: {sidebar_width}px !important; }}</style>', unsafe_allow_html=True)
-
-        # Display the content
-        st.markdown(content)
+        starter_top_info()
       else:
-        st.header(county)
-        st.subheader(state)
+        st.title(county)
+        st.header(state)
         st.header("")# Add an empty line to create space
         #TODO: create a function that pulls data given the country and state
         st.header("Operating Facilities")
-        st.text("CAA: " + str(CAA_value))
-        st.text("CWA: " + str(CWA_value))
-        st.text("RCRA: " + str(RCRA_value))
+        st.subheader("CAA: " + str(CAA_value))
+        st.subheader("CWA: " + str(CWA_value))
+        st.subheader("RCRA: " + str(RCRA_value))
         with st.container():
-          grading, highlight, compliance, non_compliance = st.tabs(["Grading", "Highlights", "District in Compliance", "Recent Non-Compliance"])
-
+          grading, highlight, comparison, non_compliance = st.tabs(["Grading", "Highlights", "In Comparison", "Recent Non-Compliance"])
           with grading:
-            #TODO: need a function here that grabs the information to be shown
-            gradingTab("test")
+            #TODO: need a function here that grabs the information to be shown & need the links 
+            gradingTabData()
+            bottom_info()
+            gradingTabInfo()
 
           with highlight:
-            pass
+            #TODO: make a highlightTabData() for the graphs
+            bottom_info()
+            highlightTabInfo()
 
-          with compliance:
-            pass
+          with comparison:
+            #TODO: make a comparisonTabData() for the graphs
+            bottom_info()
+            comparisonTabInfo()
+            
 
           with non_compliance:
-            pass
+            #TODO: make a complianceTabData() for the graphs
+            bottom_info()
 
 
 # Information that is shown when button is clicked
 if st.session_state.button:
     # User opens the sidebar
     with st.sidebar:
-      fillSideBar() #starter
-      #fillSideBar("hi","test", 72, 73,74)
+      #fillSideBar() #starter
+      fillSideBar("hi","test", 72, 73,74)

--- a/style.css
+++ b/style.css
@@ -1,0 +1,9 @@
+.st-emotion-cache-18ni7ap.ezrtsby2 {
+  background-color: rgb(122, 195, 231) !important;
+  top: 100px !important;
+}
+
+.appview-container.st-emotion-cache-1wrcr25.ea3mdgi6 {
+  background-color: rgb(122, 195, 231) !important;
+  top: 100px !important;
+}


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->

## Overview

Moved the default streamlit header down 100px to make room for the coming navbar

## Replication

Do streamlit run header.py

<!-- How can someone test your code. -->

## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

The identifier of the elements were found using inspect element on the website itself, and then they were styled using CSS in a separate styling file. The st header was moved down, and the div under it was also moved down by 100px. Both were colored blue just to show their new position.

## Next Steps 

Add the navbar itself to the top of the page, add something that says EDGI to the top of the page

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->

## Screenshots

<!-- This could include of screenshots of the new feature / proof that the changes work. -->

<details>

  <summary>Screen Shot Name</summary>

  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->

</details>

Closes #12 